### PR TITLE
Add "Xenophanes"

### DIFF
--- a/data/sources/manual.txt
+++ b/data/sources/manual.txt
@@ -21,3 +21,8 @@ David Hilbert: country=Germany
 
 # https://github.com/ybogdanov/history-timeline/issues/21
 Martti Ahtisaari: country=Finland
+
+# First test contribution, related to: https://github.com/ybogdanov/history-timeline/issues/37
+# Sourced from: https://en.wikipedia.org/wiki/Xenophanes
+# Currently he is mapped to "science" area type, but would like to have opportunity to change to type=philosophy
+Xenophanes: from=-570 to=–475 country=Greece type=science


### PR DESCRIPTION
First test contribution, related to: https://github.com/ybogdanov/history-timeline/issues/37

I would like to see that this makes it through, before I add the rest of the philosophers manually.
Ideally, they should be automatically sourced from Wikipedia.
Maybe that requires an updated `wikipedia.xml` dump, or simply a new extraction from it which includes all philosophers?